### PR TITLE
ref(docs): add TSDocs to the types

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ function App() {
   return (
     <div>
        <LazyList
-          classes={
+          classes={{
             root: "lazy-list-container"
-          }
+          }}
           dataLoader={loadData}
           renderFunction={
             (node: Node) => <NodeItem node={node} />

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4927,10 +4927,10 @@ react-app-polyfill@^1.0.0:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
-react-async-lazy-list@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-async-lazy-list/-/react-async-lazy-list-0.2.0.tgz#fedf81795213e70e147685cf62195bd311837044"
-  integrity sha512-IFDazYKnzeh9QSvCA/g0fYf1ZlUj6k6IQueniDZ7ICA6Mxw0vi89EdD9fi1X9Ku7MzkarlHVtu32VVEf0DGptw==
+react-async-lazy-list@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/react-async-lazy-list/-/react-async-lazy-list-0.2.1.tgz#539cbede030498e15b7ceb30af3f89c12cf927b7"
+  integrity sha512-X+n3ufNotixXjV3fgl2kOXON2Qz4p4gHtzjNkZCcLDEg0TVUW8uSMahaRx++MXbOlxrzNaZgG8KxgJyOLxxi+g==
 
 react-dom@^18.2.0:
   version "18.2.0"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,15 +37,33 @@ export type RenderFunction<T> = (
 ) => React.ReactElement;
 
 export interface LazyListClasses {
+  /** Classname for root container. */
   root?: string;
+
+  /** Classname for loading container */
   loadingContainer?: string;
+
+  /** Classname for node container */
   nodeContainer?: string;
+
+  /** Classname for group container */
   groupContainer?: string;
+
+  /** Classname for footer container */
   footerContainer?: string;
 }
 
 export interface AsyncLazyLoadOptions {
+  /**
+   * Pre fetch/buffer size in pixels.
+   * @defaultValue `50`
+   */
   bufferOffset?: number;
+
+  /**
+   * Limit scroll event process with at most 1 fires every X ms.
+   * @defaultValue `60`
+   */
   scrollThrottle?: number;
 }
 
@@ -60,12 +78,72 @@ export interface GroupProps<T> {
 }
 
 export interface AsyncLazyListProps<T> {
+  /**
+   * Loader function that retrieves the data.
+   * @example
+   * ```ts
+   * const loadData = (idx: number): Promise<Node[]> =>
+   * fetchData("some_url", {
+   * page: (idx + 1),
+   * size: 10
+   * })
+   * ```
+   */
   dataLoader: AsyncItemsLoader<T>;
+
+  /**
+   * Renderer function to render the nodes.
+   *
+   * @example
+   * ```ts
+   * renderFunction={
+   *   (node: Node) => <NodeItem node={node} />
+   * }
+   * ```
+   *
+   *
+   * @returns JSX Element to render.
+   * @typeParam T - Type of the node.
+   */
   renderFunction: RenderFunction<T>;
+
+  /**
+   * Classnames for different LazyList Elements.
+   *
+   * @example
+   * ```ts
+   * <ReactAsyncLazyList
+   * classes={{
+   *  root: "lazy-root",
+   *  loadingContainer: "lazy-container",
+   *  ...
+   * }}
+   * />
+   * ```
+   *
+   * @see {@link https://github.com/sawrozpdl/react-async-lazy-list#properties  React Async Lazy List - Properties}
+   */
   classes?: LazyListClasses;
+
+  /** CSS styles properties. */
   style?: React.CSSProperties;
+
+  /** Divider that divides the lists. */
   dividerComponent?: React.ReactElement;
+
+  /** Loader to render while the list is loading. */
   loadingComponent?: React.ReactElement;
+
+  /** JSX Element to render at the end of the list. */
   footerComponent?: React.ReactElement;
+
+  /**
+   * Different options for lazy list loading.
+   * |Property|
+   * :----------------
+   * `bufferOffset`
+   * `scrollThrottle`
+   * @see {@link https://github.com/sawrozpdl/react-async-lazy-list#options React Async Lazy List - Options}
+   */
   options?: AsyncLazyLoadOptions;
 }


### PR DESCRIPTION
I have added Docs comments (TSDocs) into some props of the elements to make it more developer friendly.

Doing so will help different tools (like vscode) extract content without getting confused by each other’s markup.

``On hovering over the properties vs code will popup informations about the properties.``
![image](https://user-images.githubusercontent.com/56839074/194556270-2fa2c965-8e6b-45d7-844c-afeccce424d0.png)
